### PR TITLE
[release-2.9] Build dynamically linked binary

### DIFF
--- a/.promu.dynamic.yaml
+++ b/.promu.dynamic.yaml
@@ -1,0 +1,23 @@
+go:
+    # Whenever the Go version is updated here, .circle/config.yml should also
+    # be updated.
+    version: 1.20
+repository:
+    path: github.com/prometheus/memcached_exporter
+build:
+    static: false
+    binaries:
+        - name: memcached_exporter
+          path: ./cmd/memcached_exporter
+    ldflags: |
+        -X github.com/prometheus/common/version.Version={{.Version}}
+        -X github.com/prometheus/common/version.Revision={{.Revision}}
+        -X github.com/prometheus/common/version.Branch={{.Branch}}
+        -X github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
+        -X github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
+tarball:
+    files:
+        - README.md
+        - CHANGELOG.md
+        - LICENSE
+        - NOTICE

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,0 +1,17 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux as builder
+
+WORKDIR /workspace
+COPY . .
+
+RUN make -f Makefile.dynamic common-build
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+
+COPY memcached_exporter /bin/memcached_exporter
+
+USER       nobody
+ENTRYPOINT ["/bin/memcached_exporter"]
+EXPOSE     9150

--- a/Makefile.common.dynamic
+++ b/Makefile.common.dynamic
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+include Makefile.common
+
+# Override common-build target to build dynamically linked binary
+.PHONY: common-build
+common-build: promu
+	@echo ">> building dynamic binaries"
+	$(PROMU) -c ".promu.dynamic.yaml" build -v --cgo --prefix $(PREFIX) $(PROMU_BINARIES)

--- a/Makefile.dynamic
+++ b/Makefile.dynamic
@@ -1,0 +1,19 @@
+# Copyright 2015 The Prometheus Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Needs to be defined before including Makefile.common to auto-generate targets
+DOCKER_ARCHS ?= amd64 armv7 arm64
+
+include Makefile.common.dynamic
+
+DOCKER_IMAGE_NAME ?= memcached-exporter


### PR DESCRIPTION
Use promu dynamic linking flags to build a dynamically linked binary.

A PR is needed in openshift/release repo to reference newly created files, after this PR is merged.
