### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for memcached-exporter-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -16,7 +16,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 COPY --from=builder /workspace/memcached_exporter /bin/memcached_exporter
 
 LABEL com.redhat.component="memcached-exporter" \
-    name="stolostron/memcached_exportor" \
+    name="rhacm2/memcached-exporter-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.14::el9" \
     summary="stolostron/memcached_exporter" \
     description="Memcached Exporter for Prometheus" \
     io.openshift.tags="observability" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
