### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -7,9 +7,9 @@ WORKDIR /workspace
 COPY . .
 
 # build promu
-RUN cd promu && go build -mod=mod -o /cachi2/output/deps/gomod/bin/promu
+RUN cd promu && CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -mod=mod -o /cachi2/output/deps/gomod/bin/promu
 
-RUN make -f Makefile.dynamic common-build
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make -f Makefile.dynamic common-build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847